### PR TITLE
Boost.Test warning fixes

### DIFF
--- a/extras/boost_test/include/rapidcheck/boost_test.h
+++ b/extras/boost_test/include/rapidcheck/boost_test.h
@@ -8,13 +8,17 @@ namespace rc {
 namespace detail {
 
 template <typename Testable>
-void checkBoostTest(const std::string &description, Testable &&testable) {
+void checkBoostTest(Testable &&testable) {
   const auto &testCase = boost::unit_test::framework::current_test_case();
   TestMetadata metadata;
   metadata.id = testCase.full_name();
   metadata.description = testCase.p_name;
 
   const auto result = checkTestable(std::forward<Testable>(testable), metadata);
+
+  //Without this boost.test will complain about the test case having no assertions when the
+  //rapidcheck test passes
+  BOOST_CHECK (true);
 
   if (result.template is<SuccessResult>()) {
     const auto success = result.template get<SuccessResult>();
@@ -39,7 +43,7 @@ void checkBoostTest(const std::string &description, Testable &&testable) {
   void rapidCheck_propImpl_##Name ArgList;                                     \
                                                                                \
   BOOST_AUTO_TEST_CASE(Name) {                                                 \
-    ::rc::detail::checkBoostTest(#Name, &rapidCheck_propImpl_##Name);          \
+    ::rc::detail::checkBoostTest(&rapidCheck_propImpl_##Name);          \
   }                                                                            \
                                                                                \
   void rapidCheck_propImpl_##Name ArgList
@@ -55,8 +59,7 @@ void checkBoostTest(const std::string &description, Testable &&testable) {
   };                                                                           \
                                                                                \
   BOOST_AUTO_TEST_CASE(Name) {                                                 \
-    ::rc::detail::checkBoostTest(                                              \
-        #Name,                                                                 \
+     ::rc::detail::checkBoostTest(                                      \
         &rc::detail::ExecFixture<                                              \
             RapidCheckPropImpl_##Fixture##_##Name>::exec);                     \
   }                                                                            \

--- a/include/rapidcheck/Gen.hpp
+++ b/include/rapidcheck/Gen.hpp
@@ -71,13 +71,6 @@ Shrinkable<T> Gen<T>::operator()(const Random &random, int size) const
     auto exception = std::current_exception();
     return shrinkable::lambda([=]() -> T {
       std::rethrow_exception(exception);
-
-      // MSVC HACK: the following is required for MSVC to stop complaining
-      //            about missing return value. Will never be reached, of
-      //            course.
-#ifdef _MSC_VER
-      throw nullptr;
-#endif // _MSC_VER
     });
   }
 }


### PR DESCRIPTION
Fixes some compiler and runtime warnings when using Boost.Test and VS2015.